### PR TITLE
feat: add admin ui and seperate components with mock setting

### DIFF
--- a/frontend/src/__MOCK__/mock.tsx
+++ b/frontend/src/__MOCK__/mock.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { Table, Tag, Space } from "antd";
+
+export const columns = [
+  {
+    title: "Name",
+    dataIndex: "name",
+    key: "name",
+    render: (text: any) => <a>{text}</a>,
+  },
+  {
+    title: "Age",
+    dataIndex: "age",
+    key: "age",
+  },
+  {
+    title: "Address",
+    dataIndex: "address",
+    key: "address",
+  },
+  {
+    title: "Tags",
+    key: "tags",
+    dataIndex: "tags",
+    render: (tags: any) => (
+      <>
+        {tags.map((tag: any) => {
+          let color = tag.length > 5 ? "geekblue" : "green";
+          if (tag === "loser") {
+            color = "volcano";
+          }
+          return (
+            <Tag color={color} key={tag}>
+              {tag.toUpperCase()}
+            </Tag>
+          );
+        })}
+      </>
+    ),
+  },
+  {
+    title: "Action",
+    key: "action",
+    render: (text: any, record: any) => (
+      <Space size="middle">
+        <a>Invite {record.name}</a>
+        <a>Delete</a>
+      </Space>
+    ),
+  },
+];
+
+export const data = [
+  {
+    key: "1",
+    name: "John Brown",
+    age: 32,
+    address: "New York No. 1 Lake Park",
+    tags: ["nice", "developer"],
+  },
+  {
+    key: "2",
+    name: "Jim Green",
+    age: 42,
+    address: "London No. 1 Lake Park",
+    tags: ["loser"],
+  },
+  {
+    key: "3",
+    name: "Joe Black",
+    age: 32,
+    address: "Sidney No. 1 Lake Park",
+    tags: ["cool", "teacher"],
+  },
+];

--- a/frontend/src/__MOCK__/mock.tsx
+++ b/frontend/src/__MOCK__/mock.tsx
@@ -3,25 +3,20 @@ import { Tag, Badge, Space } from "antd";
 
 export const columns = [
   {
-    title: "Name",
-    dataIndex: "name",
-    key: "name",
+    title: "Title",
+    dataIndex: "title",
+    key: "title",
     render: (text: any) => <a>{text}</a>,
   },
   {
-    title: "Age",
-    dataIndex: "age",
-    key: "age",
+    title: "Content",
+    dataIndex: "content",
+    key: "content",
   },
   {
-    title: "Address",
-    dataIndex: "address",
-    key: "address",
-  },
-  {
-    title: "Tags",
-    key: "tags",
-    dataIndex: "tags",
+    title: "Subject",
+    key: "subject",
+    dataIndex: "subject",
     render: (tags: any) => (
       <>
         {tags.map((tag: any) => {
@@ -43,7 +38,7 @@ export const columns = [
     key: "action",
     render: (text: any, record: any) => (
       <Space size="middle">
-        <a>Invite {record.name}</a>
+        <a>Update</a>
         <a>Delete</a>
       </Space>
     ),
@@ -53,49 +48,49 @@ export const columns = [
 export const data = [
   {
     key: "1",
-    name: "John Brown",
-    age: 32,
-    address: "New York No. 1 Lake Park",
-    tags: ["nice", "developer"],
+    title: "diet video",
+    content: "contents",
+    subject: ["diet"],
+    category: "video",
   },
   {
     key: "2",
-    name: "Jim Green",
-    age: 42,
-    address: "London No. 1 Lake Park",
-    tags: ["loser"],
+    title: "meal 1",
+    content: "contents",
+    subject: ["muscle"],
+    category: "meal",
   },
   {
     key: "3",
-    name: "Joe Black",
-    age: 32,
-    address: "Sidney No. 1 Lake Park",
-    tags: ["cool", "teacher"],
+    title: "equipment1",
+    content: "contents",
+    subject: ["diet"],
+    category: "equipment",
   },
 ];
 
 export const userExpandColumns = [
+  { title: "Goal", dataIndex: "goal", key: "goal" },
+  { title: "Detailed", dataIndex: "detailed", key: "detailed" },
   { title: "Date", dataIndex: "date", key: "date" },
-  { title: "Name", dataIndex: "name", key: "name" },
   {
-    title: "Status",
-    key: "state",
-    render: () => (
-      <span>
-        <Badge status="success" />
-        Finished
-      </span>
-    ),
-  },
-  {
-    title: "Action",
-    dataIndex: "operation",
-    key: "operation",
-    render: () => (
-      <Space size="middle">
-        <a>Pause</a>
-        <a>Stop</a>
-      </Space>
+    title: "CheckDate",
+    key: "checkdate",
+    dataIndex: "checkdate",
+    render: (tags: any) => (
+      <>
+        {tags.map((tag: any) => {
+          let color = tag.length > 5 ? "geekblue" : "green";
+          if (tag === "loser") {
+            color = "volcano";
+          }
+          return (
+            <Tag color={color} key={tag}>
+              {tag.toUpperCase()}
+            </Tag>
+          );
+        })}
+      </>
     ),
   },
 ];
@@ -103,8 +98,10 @@ export const userExpandColumns = [
 export const userExpandData = [
   {
     key: 0,
-    date: "2014-12-24 23:12:00",
-    name: "This is production name",
+    date: "2019-12-24 23:12:00",
+    goal: "diet",
+    detailed: "-5kg",
+    checkdate: ["MON", "TUE"],
   },
 ];
 
@@ -119,5 +116,5 @@ export const userData = [
 export const userColumns = [
   { title: "Name", dataIndex: "name", key: "name" },
   { title: "Create date", dataIndex: "createdAt", key: "createdAt" },
-  { title: "Action", key: "operation", render: () => <a>Do something</a> },
+  { title: "Action", key: "operation", render: () => <a>Delete</a> },
 ];

--- a/frontend/src/__MOCK__/mock.tsx
+++ b/frontend/src/__MOCK__/mock.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Table, Tag, Space } from "antd";
+import { Tag, Badge, Space } from "antd";
 
 export const columns = [
   {
@@ -72,4 +72,52 @@ export const data = [
     address: "Sidney No. 1 Lake Park",
     tags: ["cool", "teacher"],
   },
+];
+
+export const userExpandColumns = [
+  { title: "Date", dataIndex: "date", key: "date" },
+  { title: "Name", dataIndex: "name", key: "name" },
+  {
+    title: "Status",
+    key: "state",
+    render: () => (
+      <span>
+        <Badge status="success" />
+        Finished
+      </span>
+    ),
+  },
+  {
+    title: "Action",
+    dataIndex: "operation",
+    key: "operation",
+    render: () => (
+      <Space size="middle">
+        <a>Pause</a>
+        <a>Stop</a>
+      </Space>
+    ),
+  },
+];
+
+export const userExpandData = [
+  {
+    key: 0,
+    date: "2014-12-24 23:12:00",
+    name: "This is production name",
+  },
+];
+
+export const userData = [
+  {
+    key: 0,
+    name: `User`,
+    createdAt: "2014-12-24 23:12:00",
+  },
+];
+
+export const userColumns = [
+  { title: "Name", dataIndex: "name", key: "name" },
+  { title: "Create date", dataIndex: "createdAt", key: "createdAt" },
+  { title: "Action", key: "operation", render: () => <a>Do something</a> },
 ];

--- a/frontend/src/components/admin/RecommendManageTable.tsx
+++ b/frontend/src/components/admin/RecommendManageTable.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Table, Tag, Space } from "antd";
+import { ColumnsType } from "antd/lib/table";
+
+interface IProps {
+  columns: ColumnsType<any>;
+  data: any;
+  title: string;
+}
+
+const RecommendManageTable: React.FC<IProps> = ({ columns, data, title }) => {
+  return (
+    <div>
+      <h1>{title} page</h1>
+      <Table columns={columns} dataSource={data} />
+    </div>
+  );
+};
+
+export default RecommendManageTable;

--- a/frontend/src/components/admin/RecommendManageTable.tsx
+++ b/frontend/src/components/admin/RecommendManageTable.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Table, Tag, Space } from "antd";
+import { Table } from "antd";
 import { ColumnsType } from "antd/lib/table";
 
 interface IProps {

--- a/frontend/src/components/admin/UserExpandRender.tsx
+++ b/frontend/src/components/admin/UserExpandRender.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Table } from "antd";
+import { ColumnsType } from "antd/lib/table";
+
+import { userExpandColumns, userExpandData } from "__MOCK__/mock";
+
+interface IProps {
+  data: any;
+  columns: ColumnsType<any>;
+}
+
+const UserExpandedRowRender: React.FC<IProps> = ({
+  data = userExpandData,
+  columns = userExpandColumns,
+}) => {
+  return <Table columns={columns} dataSource={data} pagination={false} />;
+};
+
+export default UserExpandedRowRender;

--- a/frontend/src/components/admin/UserManageTable.tsx
+++ b/frontend/src/components/admin/UserManageTable.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { Table, Badge, Menu, Dropdown, Space } from "antd";
+import { DownOutlined } from "@ant-design/icons";
+
+const menu = (
+  <Menu>
+    <Menu.Item>Action 1</Menu.Item>
+    <Menu.Item>Action 2</Menu.Item>
+  </Menu>
+);
+
+const UserManageTable = () => {
+  const expandedRowRender = () => {
+    const columns = [
+      { title: "Date", dataIndex: "date", key: "date" },
+      { title: "Name", dataIndex: "name", key: "name" },
+      {
+        title: "Status",
+        key: "state",
+        render: () => (
+          <span>
+            <Badge status="success" />
+            Finished
+          </span>
+        ),
+      },
+      {
+        title: "Action",
+        dataIndex: "operation",
+        key: "operation",
+        render: () => (
+          <Space size="middle">
+            <a>Pause</a>
+            <a>Stop</a>
+            <Dropdown overlay={menu}>
+              <a>
+                More <DownOutlined />
+              </a>
+            </Dropdown>
+          </Space>
+        ),
+      },
+    ];
+
+    const data = [];
+    for (let i = 0; i < 3; ++i) {
+      data.push({
+        key: i,
+        date: "2014-12-24 23:12:00",
+        name: "This is production name",
+      });
+    }
+    return <Table columns={columns} dataSource={data} pagination={false} />;
+  };
+
+  const columns = [
+    { title: "Name", dataIndex: "name", key: "name" },
+    { title: "Create date", dataIndex: "createdAt", key: "createdAt" },
+    { title: "Action", key: "operation", render: () => <a>Do something</a> },
+  ];
+
+  const data = [];
+  for (let i = 0; i < 3; ++i) {
+    data.push({
+      key: i,
+      name: `User${i}`,
+      createdAt: "2014-12-24 23:12:00",
+    });
+  }
+
+  return (
+    <Table
+      columns={columns}
+      expandable={{ expandedRowRender }}
+      dataSource={data}
+    />
+  );
+};
+
+export default UserManageTable;

--- a/frontend/src/components/admin/UserManageTable.tsx
+++ b/frontend/src/components/admin/UserManageTable.tsx
@@ -1,73 +1,15 @@
 import React from "react";
-import { Table, Badge, Menu, Dropdown, Space } from "antd";
-import { DownOutlined } from "@ant-design/icons";
+import { Table } from "antd";
+import { ColumnsType } from "antd/lib/table";
 
-const menu = (
-  <Menu>
-    <Menu.Item>Action 1</Menu.Item>
-    <Menu.Item>Action 2</Menu.Item>
-  </Menu>
-);
+import expandedRowRender from "./UserExpandRender";
 
-const UserManageTable = () => {
-  const expandedRowRender = () => {
-    const columns = [
-      { title: "Date", dataIndex: "date", key: "date" },
-      { title: "Name", dataIndex: "name", key: "name" },
-      {
-        title: "Status",
-        key: "state",
-        render: () => (
-          <span>
-            <Badge status="success" />
-            Finished
-          </span>
-        ),
-      },
-      {
-        title: "Action",
-        dataIndex: "operation",
-        key: "operation",
-        render: () => (
-          <Space size="middle">
-            <a>Pause</a>
-            <a>Stop</a>
-            <Dropdown overlay={menu}>
-              <a>
-                More <DownOutlined />
-              </a>
-            </Dropdown>
-          </Space>
-        ),
-      },
-    ];
+interface IProps {
+  data: any;
+  columns: ColumnsType<any>;
+}
 
-    const data = [];
-    for (let i = 0; i < 3; ++i) {
-      data.push({
-        key: i,
-        date: "2014-12-24 23:12:00",
-        name: "This is production name",
-      });
-    }
-    return <Table columns={columns} dataSource={data} pagination={false} />;
-  };
-
-  const columns = [
-    { title: "Name", dataIndex: "name", key: "name" },
-    { title: "Create date", dataIndex: "createdAt", key: "createdAt" },
-    { title: "Action", key: "operation", render: () => <a>Do something</a> },
-  ];
-
-  const data = [];
-  for (let i = 0; i < 3; ++i) {
-    data.push({
-      key: i,
-      name: `User${i}`,
-      createdAt: "2014-12-24 23:12:00",
-    });
-  }
-
+const UserManageTable: React.FC<IProps> = ({ data, columns }) => {
   return (
     <Table
       columns={columns}

--- a/frontend/src/pages/admin/home.tsx
+++ b/frontend/src/pages/admin/home.tsx
@@ -61,7 +61,7 @@ const Home = () => {
               <UserManageTable columns={userColumns} data={userData} />
             ) : (
               <RecommendManageTable
-                data={data}
+                data={data.filter((data) => data.category === selectedKey)}
                 columns={columns}
                 title={selectedKey}
               />

--- a/frontend/src/pages/admin/home.tsx
+++ b/frontend/src/pages/admin/home.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from "react";
 import { Layout, Menu, Breadcrumb } from "antd";
 import { UserOutlined } from "@ant-design/icons";
+
+import UserManageTable from "components/admin/UserManageTable";
+import RecommendManageTable from "components/admin/RecommendManageTable";
+import { data, columns } from "__MOCK__/mock";
+
 import styles from "./styles.module.scss";
 
 const { SubMenu } = Menu;
@@ -52,7 +57,15 @@ const Home = () => {
               minHeight: 280,
             }}
           >
-            {selectedKey} page
+            {selectedKey === "user" ? (
+              <UserManageTable />
+            ) : (
+              <RecommendManageTable
+                data={data}
+                columns={columns}
+                title={selectedKey}
+              />
+            )}
           </Content>
         </Layout>
       </Layout>

--- a/frontend/src/pages/admin/home.tsx
+++ b/frontend/src/pages/admin/home.tsx
@@ -4,7 +4,7 @@ import { UserOutlined } from "@ant-design/icons";
 
 import UserManageTable from "components/admin/UserManageTable";
 import RecommendManageTable from "components/admin/RecommendManageTable";
-import { data, columns } from "__MOCK__/mock";
+import { data, columns, userColumns, userData } from "__MOCK__/mock";
 
 import styles from "./styles.module.scss";
 
@@ -58,7 +58,7 @@ const Home = () => {
             }}
           >
             {selectedKey === "user" ? (
-              <UserManageTable />
+              <UserManageTable columns={userColumns} data={userData} />
             ) : (
               <RecommendManageTable
                 data={data}


### PR DESCRIPTION
**Descriptions:**

- add admin UI
- seperate components with ant-design built in component
- add mock data

**Related issue:**

- https://github.com/covid19-cau/capstone-design-project/issues/19

**Memo:**
<img width="1025" alt="스크린샷 2020-10-02 오후 3 32 07" src="https://user-images.githubusercontent.com/26598542/94894580-9da6fd80-04c4-11eb-9c9a-b9f6c16a3f2f.png">
<img width="1020" alt="스크린샷 2020-10-02 오후 3 31 59" src="https://user-images.githubusercontent.com/26598542/94894586-a1d31b00-04c4-11eb-9cb9-e2688fcd260c.png">

